### PR TITLE
Save ID/OD boundary traj points in WCSimRootTrack

### DIFF
--- a/include/WCSimRootEvent.hh
+++ b/include/WCSimRootEvent.hh
@@ -43,6 +43,9 @@ private:
   Double_t fTime;
   Int_t fId;
   Int_t fParentId;
+  std::vector<std::vector<double>> boundaryPoints;
+  std::vector<double> boundaryKEs;
+  std::vector<int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 
 public:
   WCSimRootTrack() {}
@@ -60,7 +63,10 @@ public:
 		 Int_t parenttype,
 		 Double_t time,
 		 Int_t id,
-		 Int_t idParent);
+		 Int_t idParent,
+     std::vector<std::vector<double>> bPs,
+     std::vector<double> bKEs,
+     std::vector<int> bTypes);
   virtual ~WCSimRootTrack() { }
   bool CompareAllVariables(const WCSimRootTrack * c) const;
 
@@ -79,8 +85,11 @@ public:
   Double_t   GetTime() const { return fTime;}
   Int_t     GetId() const {return fId;}
   Int_t     GetParentId() const {return fParentId;}
+  std::vector<std::vector<double>> GetBoundaryPoints() {return boundaryPoints;}
+  std::vector<double> GetBoundaryKEs() {return boundaryKEs;}
+  std::vector<int> GetBoundaryTypes() {return boundaryTypes;}
 
-  ClassDef(WCSimRootTrack,3)
+  ClassDef(WCSimRootTrack,4)
 };
 
 
@@ -447,7 +456,10 @@ public:
 				   Int_t parenttype,
 				   Double_t time,
 				   Int_t id,
-				   Int_t idParent);
+				   Int_t idParent,
+           std::vector<std::vector<double>> bPs,
+           std::vector<double> bKEs,
+           std::vector<int> bTypes);
 
   WCSimRootTrack * AddTrack   (WCSimRootTrack * track);
   WCSimRootTrack * RemoveTrack(WCSimRootTrack * track);
@@ -480,7 +492,7 @@ public:
 
   TClonesArray	      *GetCaptures() const {return fCaptures;}
 
-  ClassDef(WCSimRootTrigger,4) //WCSimRootEvent structure
+  ClassDef(WCSimRootTrigger,5) //WCSimRootEvent structure
 };
 
 

--- a/include/WCSimTrajectory.hh
+++ b/include/WCSimTrajectory.hh
@@ -72,6 +72,26 @@ public: // with description
    inline void SetStoppingVolume(G4VPhysicalVolume* currentVolume)
    { stoppingVolume = currentVolume;}
 
+// Functions to Set/Get boundary points
+  inline void SetBoundaryPoints(std::vector<std::vector<G4double>> bPs,
+                                std::vector<G4double> bKEs,
+                                std::vector<G4int> bTypes)
+  {
+    boundaryPoints = bPs;
+    boundaryKEs = bKEs;
+    boundaryTypes = bTypes;
+  }
+  inline void AddBoundaryPoint(std::vector<G4double> bPs,
+                               G4double bKEs,
+                               G4int bTypes)
+  {
+    boundaryPoints.push_back(bPs);
+    boundaryKEs.push_back(bKEs);
+    boundaryTypes.push_back(bTypes);
+  }
+  inline std::vector<std::vector<G4double>> GetBoundaryPoints() {return boundaryPoints;}
+  inline std::vector<G4double> GetBoundaryKEs() {return boundaryKEs;}
+  inline std::vector<G4int> GetBoundaryTypes() {return boundaryTypes;}
 
 // Other member functions
    virtual void ShowTrajectory(std::ostream& os=G4cout) const;
@@ -107,6 +127,11 @@ public: // with description
   G4bool SaveIt;
   G4String creatorProcess;
   G4double                  globalTime;
+
+  // Boundary points;
+  std::vector<std::vector<G4double>> boundaryPoints;
+  std::vector<G4double> boundaryKEs;
+  std::vector<G4int> boundaryTypes; // 1 = blacksheet, 2 = tyvek, 3 = cave
 };
 
 /***            TEMP  : M FECHNER ***********

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -1210,7 +1210,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
 			      injhfNtuple.parent[k],
 			      injhfNtuple.time[k],
                   0,
-                  0);
+                  0,
+                  std::vector<std::vector<double>>(),
+                  std::vector<double>(),
+                  std::vector<int>());
   }
 
   // the rest of the tracks come from WCSimTrajectory
@@ -1350,7 +1353,10 @@ void WCSimEventAction::FillRootEvent(G4int event_id,
                                    parentType,
                                    ttime,
                                    id,
-                                   idPrnt);
+                                   idPrnt,
+                                   trj->GetBoundaryPoints(),
+                                   trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTypes());
       }
 
 
@@ -1742,7 +1748,10 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
 			      injhfNtuple.parent[k],
 			     injhfNtuple.time[k],
                  0,
-                 0);
+                 0,
+                 std::vector<std::vector<double>>(),
+                 std::vector<double>(),
+                 std::vector<int>());
   }
 
   // the rest of the tracks come from WCSimTrajectory
@@ -1878,7 +1887,10 @@ void WCSimEventAction::FillRootEventHybrid(G4int event_id,
                                    parentType,
                                    ttime,
                                    id,
-                                   idPrnt);
+                                   idPrnt,
+                                   trj->GetBoundaryPoints(),
+                                   trj->GetBoundaryKEs(),
+                                   trj->GetBoundaryTypes());
       }
 
 

--- a/src/WCSimRootEvent.cc
+++ b/src/WCSimRootEvent.cc
@@ -404,7 +404,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 					   Int_t parenttype,
 					   Double_t time,
 					   Int_t id,
-					   Int_t idParent)
+					   Int_t idParent,
+             std::vector<std::vector<double>> bPs,
+             std::vector<double> bKEs,
+             std::vector<int> bTypes)
 {
   // Add a new WCSimRootTrack to the list of tracks for this event.
   // To avoid calling the very time consuming operator new for each track,
@@ -428,7 +431,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(Int_t ipnu,
 						parenttype,
 						time,
 						id,
-						idParent);
+						idParent,
+            bPs,
+            bKEs,
+            bTypes);
   fNtrack++;
   return track;
 }
@@ -466,7 +472,10 @@ WCSimRootTrack *WCSimRootTrigger::AddTrack(WCSimRootTrack * track)
 					  track->GetParenttype(),
 					  track->GetTime(),
 					  track->GetId(),
-					  track->GetParentId());
+					  track->GetParentId(),
+            track->GetBoundaryPoints(),
+            track->GetBoundaryKEs(),
+            track->GetBoundaryTypes());
   fNtrack++;
   return track_out;
 }
@@ -497,7 +506,10 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
 			       Int_t parenttype,
 			       Double_t time,
 			       Int_t id,
-			       Int_t idParent)
+			       Int_t idParent,
+             std::vector<std::vector<double>> bPs,
+             std::vector<double> bKEs,
+             std::vector<int> bTypes)
 {
 
   // Create a WCSimRootTrack object and fill it with stuff
@@ -521,6 +533,9 @@ WCSimRootTrack::WCSimRootTrack(Int_t ipnu,
   fTime = time;
   fId = id;
   fParentId = idParent;
+  boundaryPoints = bPs;
+  boundaryKEs = bKEs;
+  boundaryTypes = bTypes;
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Check pre-step and post-step volume names and save trajectory points whenever crossing ID blacksheet or OD tyvek.
These trajectory points are saved within `WCSimRootTrack` class and can be accessed with functions `GetBoundaryPoints`, etc.

For example, for a muon travelling downward from ID to OD, these trajectory points are saved
```
Pos -2746.17 -4000 -1176.95  KE 1899.06 Type 1 // ID-blacksheet boundary
Pos -2746.02 -4020 -1176.87  KE 1895.82 Type 1 // blacksheet-deadspace boundary
Pos -2744.79 -4199.5 -1176.08  KE 1855.74 Type 2 // deadspace-inner tyvek boundary
Pos -2744.79 -4200.5 -1176.07  KE 1855.67 Type 2 // inner tyvek-OD boundary
Pos -2744.16 -5221.5 -1179.85  KE 1552.17 Type 3 // OD-outer tyvek boundary
Pos -2744.15 -5222.5 -1179.86  KE 1552.12 Type 3 // outer tyvek-outside world boundary
```